### PR TITLE
fixed ‘photo setup’ for the first image

### DIFF
--- a/src/AGPhotoBrowserView.m
+++ b/src/AGPhotoBrowserView.m
@@ -75,7 +75,7 @@ const NSInteger AGPhotoBrowserThresholdToCenter = 150;
 {
 	NSInteger number = [_dataSource numberOfPhotosForPhotoBrowser:self];
     
-    if (number > 0) {
+    if (number > 0 && _currentlySelectedIndex == NSNotFound) {
         // initialize with info for the first photo in photoTable
         [self setupPhotoForIndex:0];
     }


### PR DESCRIPTION
When photo browser opened up showing the first photo `scrollViewDidScroll:` wasn't called so, `_currentlySelectedIndex` was still `NSNotFound` and title/description wasn't appeared.
