### PR TITLE
Overlay Display at Top of IMage

### DIFF
--- a/src/AGPhotoBrowserView.m
+++ b/src/AGPhotoBrowserView.m
@@ -216,6 +216,7 @@ const NSInteger AGPhotoBrowserThresholdToCenter = 150;
     }
 
     [self configureCell:cell forRowAtIndexPath:indexPath];
+    [self.overlayView resetOverlayView];
     
     return cell;
 }


### PR DESCRIPTION
Fixes #25 (and related to #20).

Fixes issue where if only one image is displayed, the overlay view appeared at the top.
