### PR TITLE
Fixed Xcode 6 issue

### DIFF
--- a/src/AGPhotoBrowserOverlayView.h
+++ b/src/AGPhotoBrowserOverlayView.h
@@ -25,8 +25,8 @@ static const NSInteger AGPhotoBrowserOverlayInitialHeight = 100;
 
 @property (nonatomic, weak) id<AGPhotoBrowserOverlayViewDelegate> delegate;
 
-@property (nonatomic, copy) NSString *title;
-@property (nonatomic, copy) NSString *description;
+@property (nonatomic, copy) NSString *photoTitle;
+@property (nonatomic, copy) NSString *photoDescription;
 @property (nonatomic, strong, readonly) UIButton *actionButton;
 @property (nonatomic, strong, readonly) UILabel *titleLabel;
 @property (nonatomic, strong, readonly) UILabel *descriptionLabel;

--- a/src/AGPhotoBrowserOverlayView.m
+++ b/src/AGPhotoBrowserOverlayView.m
@@ -93,7 +93,7 @@
         self.seeMoreButton.hidden = YES;
     }
 	
-    if ([_title length]) {
+    if ([_photoTitle length]) {
 		self.titleLabel.hidden = NO;
 		self.separatorView.hidden = NO;
 	} else {
@@ -101,7 +101,7 @@
 		self.separatorView.hidden = YES;
 	}
     
-    if (![_description length] && ![_title length]) {
+    if (![_photoDescription length] && ![_photoTitle length]) {
         _gradientLayer.hidden = YES;
     } else {
         _gradientLayer.hidden = NO;
@@ -255,12 +255,12 @@
 					 }];
 }
 
-- (void)setTitle:(NSString *)title
+- (void)setPhotoTitle:(NSString *)photoTitle
 {
-	_title = title;
+	_photoTitle = photoTitle;
 	
-    if (_title) {
-        self.titleLabel.text = _title;
+    if (_photoTitle) {
+        self.titleLabel.text = _photoTitle;
     } else {
 		self.descriptionLabel.text = @"";
 	}
@@ -268,12 +268,12 @@
     [self setNeedsLayout];
 }
 
-- (void)setDescription:(NSString *)description
+- (void)setPhotoDescription:(NSString *)photoDescription
 {
-	_description = description;
+	_photoDescription = photoDescription;
 	
-	if ([_description length]) {
-		self.descriptionLabel.text = _description;
+	if ([_photoDescription length]) {
+		self.descriptionLabel.text = _photoDescription;
 	} else {
 		self.descriptionLabel.text = @"";
 	}

--- a/src/AGPhotoBrowserView.m
+++ b/src/AGPhotoBrowserView.m
@@ -287,15 +287,15 @@ const NSInteger AGPhotoBrowserThresholdToCenter = 150;
     }
     
 	if ([_dataSource respondsToSelector:@selector(photoBrowser:titleForImageAtIndex:)]) {
-		self.overlayView.title = [_dataSource photoBrowser:self titleForImageAtIndex:_currentlySelectedIndex];
+		self.overlayView.photoTitle = [_dataSource photoBrowser:self titleForImageAtIndex:_currentlySelectedIndex];
 	} else {
-        self.overlayView.title = @"";
+        self.overlayView.photoTitle = @"";
     }
 	
 	if ([_dataSource respondsToSelector:@selector(photoBrowser:descriptionForImageAtIndex:)]) {
-		self.overlayView.description = [_dataSource photoBrowser:self descriptionForImageAtIndex:_currentlySelectedIndex];
+		self.overlayView.photoDescription = [_dataSource photoBrowser:self descriptionForImageAtIndex:_currentlySelectedIndex];
 	} else {
-        self.overlayView.description = @"";
+        self.overlayView.photoDescription = @"";
     }
 }
 


### PR DESCRIPTION
I was trying to compile the project with the last Xcode 6 beta but was not compiling. So I discovered that we can't longer name an object `description`. (Even better: we never could, but the compiler never complain so far)

Ps: I changed also the `title` for `photoTitle` to maintain the consistency.
